### PR TITLE
Updated database schema

### DIFF
--- a/db/migrate/20210315184532_update_review_time_schema.rb
+++ b/db/migrate/20210315184532_update_review_time_schema.rb
@@ -1,4 +1,4 @@
-class UpdtaeReviewTimeSchema < ActiveRecord::Migration
+class UpdateReviewTimeSchema < ActiveRecord::Migration
   def change
     add_column :submission_viewing_events, :total_time, :integer
   end

--- a/db/migrate/20210315184532_update_review_time_schema.rb
+++ b/db/migrate/20210315184532_update_review_time_schema.rb
@@ -1,5 +1,5 @@
 class UpdateReviewTimeSchema < ActiveRecord::Migration
   def change
-    add_column :submission_viewing_events, :total_time, :integer
+    add_column :submission_viewing_events, :total_time, :integer, :default => 0, column_options: { null: false }
   end
 end

--- a/db/migrate/20210315184532_update_review_time_schema.rb
+++ b/db/migrate/20210315184532_update_review_time_schema.rb
@@ -1,0 +1,5 @@
+class UpdtaeReviewTimeSchema < ActiveRecord::Migration
+  def change
+    add_column :submission_viewing_events, :total_time, :integer
+  end
+end


### PR DESCRIPTION
Adds a column to the `submission_viewing_events` table called `total_time`, which we can use to accumulate total time per link, per round.